### PR TITLE
fixes #51

### DIFF
--- a/MiniatureGolf/MiniatureGolf.csproj
+++ b/MiniatureGolf/MiniatureGolf.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0-preview6.19304.6" />
-    <PackageReference Include="Telerik.UI.for.Blazor" Version="1.1.1" />
+    <PackageReference Include="Telerik.UI.for.Blazor" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiniatureGolf/Pages/_Host.cshtml
+++ b/MiniatureGolf/Pages/_Host.cshtml
@@ -24,7 +24,7 @@
 
     <link href="css/site.css" rel="stylesheet" />
 
-    <script src="https://kendo.cdn.telerik.com/blazor/1.1.1/telerik-blazor.min.js" defer></script>
+    <script src="_content/telerikuiforblazor/js/telerik-blazor.js" defer></script>
 </head>
 <body>
     <app>@(await Html.RenderComponentAsync<App>())</app>

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Telerik" value="https://nuget.telerik.com/nuget/" />
+    <!--<add key="Telerik" value="https://nuget.telerik.com/nuget/" />-->
   </packageSources>
 
   <packageSourceCredentials>


### PR DESCRIPTION
- disabled telerik nuget source in sln nuget.config so vs uses the global nuget.config
- update to teleri.ui.for.blazor 1.2.0
- changes from cdn to static asset within nuget package for the .js file of the telerik.ui.for.blazor